### PR TITLE
JavaScript components

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,15 @@ Follow Airbnb's [JavaScript](https://github.com/airbnb/javascript) guide.
 
   <Component
     foo="bar"
-    bar="foo"
-  >
+    bar="foo">
     Lorem ipsum dolor…
   </Component>
-
 
   // good
   <Component
     foo="bar"
-    bar="foo">
+    bar="foo"
+  >
     Lorem ipsum dolor…
   </Component>
   ```


### PR DESCRIPTION
Après discussion avec @Ynote et @sunny, je rouvre le débat sur la manière d'appeler les composants JS dans le HTML ; la position actuelle du `>` semble en contradiction avec ce qui a motivé le choix de ne pas aligner les valeurs dans les hash, ou d'utiliser une `,` de fin dans les hash, tableaux, et autres appels de fonctions sur plusieurs lignes.