### PR TITLE
Exclude "included" method from Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,9 @@ Documentation:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - lib/tasks/**/*
+  ExcludedMethods:
+    - included
 
 # Allow indenting multiline chained operations.
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
Cf https://github.com/KissKissBankBank/kisskissbankbank/pull/3357

Cette méthode est utilisée dans ActiveSupport::Concern pour entourer l'ensemble de la méthode. On ne se soucie donc pas de la taille du bloc.