### PR TITLE
Prefer literal syntax for lambdas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,7 +99,6 @@ Rails/CreateTableWithTimestamps:
 Style/FormatStringToken:
   EnforcedStyle: template
 
-# Do not prefer `lambda` to `->` for DSLs.
+# Prefer `->` to `lambda`.
 Style/Lambda:
-  Exclude:
-    - app/graph/**/*
+  EnforcedStyle: literal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Gem updates
 
 ## unreleased
 
+Fixes:
+- Prefer `->` to `lambda`.
+
 ## v1.2.0
 
 Features:


### PR DESCRIPTION
```rb
# bad
f = lambda { |x| x }
f = lambda do |x|
      x
    end

# good
f = ->(x) { x }
f = ->(x) do
      x
    end
```