### PR TITLE
[Style] Allow up to 10 lines in RSpec examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,10 @@ RSpec/MultipleExpectations:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+# Limit method length (default is 5)
+RSpec/ExampleLength:
+  Max: 10
+
 # Allow template token "%{foo}" since they are used in translation keys.
 Style/FormatStringToken:
   EnforcedStyle: template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Rubocop Gem updates
 ## v1.2.3
 
 Fixes:
-- Allow up to 10 lines for an rspec example
+- Allow up to 10 lines in RSpec examples
 
 ## v1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Rubocop Gem updates
 ===================
 
+## v1.2.3
+
+Fixes:
+- Allow up to 10 lines for an rspec example
+
 ## v1.2.2
 
 Fixes:


### PR DESCRIPTION
Limitation de la taille d'une spec à 10 lignes.