### PR TITLE
Disable warnings forcing us to use `unless`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ RuboCop Gem updates
 Feature:
 - Add rubocop-performance cops.
 
+Fix:
+- Allow `if !` instead of `unless`.
+
 ## v2.0.1
 
 Fix:

--- a/default.yml
+++ b/default.yml
@@ -153,3 +153,7 @@ Style/FormatStringToken:
 # Prefer `->` to `lambda`.
 Style/Lambda:
   EnforcedStyle: literal
+
+# Allow `if !` since `unless` can be harder to read.
+Style/NegatedIf:
+  Enabled: false


### PR DESCRIPTION
Par défaut RuboCop affiche un warning si on écrit `return foo if !bar` au profit de `return foo unless bar`.

Même si `unless` est parfois très lisible, je pense que de manière générale `if` est plus simple.

Je propose donc d'autoriser `if !`. (Je n'ai pas vu de règle qui permette d'interdire les `unless`.)