### PR TITLE
Add pessimistic version constraints for rubocop gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ RuboCop Gem updates
 ## Unreleased
 
 Fixes:
-- Disable `Rails/BulkChangeTable`
-- Disable `RSpec/MessageChain`
-- Disable `Style/SymbolProc` for ActiveAdmin paths
+- Add pessimistic version constraints for `rubocop*` gems.
+- Remove `bundler` dependency.
+- Disable `Rails/BulkChangeTable`.
+- Disable `RSpec/MessageChain`.
+- Disable `Style/SymbolProc` for ActiveAdmin paths.
 
 ## v2.2.0
 

--- a/fashion_police.gemspec
+++ b/fashion_police.gemspec
@@ -12,21 +12,17 @@ Gem::Specification.new do |spec|
   end
 
   # Rubocop dependency to share the same version among our projects.
-  # >= 0.59.0 for "Bundler/GemComment" cop.
-  spec.add_dependency 'rubocop', '>= 0.61.1'
+  spec.add_dependency 'rubocop', '~> 0.72.0'
 
   # Rails rules
-  spec.add_dependency 'rubocop-rails'
+  spec.add_dependency 'rubocop-rails', '~> 2.2.1'
 
   # RSpec rules
-  spec.add_dependency 'rubocop-rspec'
+  spec.add_dependency 'rubocop-rspec', '~> 1.33.0'
 
   # Performance hints
-  spec.add_dependency 'rubocop-performance'
+  spec.add_dependency 'rubocop-performance', '~> 1.4.0'
 
   # Task launcher.
-  spec.add_dependency 'rake'
-
-  # Build tool.
-  spec.add_dependency 'bundler'
+  spec.add_development_dependency 'rake', '~> 12.3.2'
 end


### PR DESCRIPTION
Afin d'être certain de partager les mêmes règles partout et que les fichiers de configuration restent compatibles, on ajoute des contraintes pessimistes aux gemmes.

Aussi, retire dépendance à `bundler`, qui ne devrait pas servir.

Aussi, transforme la dépendance de `rack` en une dépendance que en développement.