### PR TITLE
[Stability] Bump target ruby version from 2.3 to 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ RuboCop Gem updates
 
 ## Unreleased
 
+Fixes:
+- Bump TargetRubyVersion to 2.4
+
 ## v2.4.2
 
 Fixes:

--- a/default.yml
+++ b/default.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
 
 # Do not sort gems in Gemfile, since we are grouping them by functionality.


### PR DESCRIPTION
![Capture d’écran 2020-08-28 à 16 28 48](https://user-images.githubusercontent.com/2332215/91579219-95025b00-e94b-11ea-985f-dd1f5c272db1.png)
